### PR TITLE
set the plugin version correctly in the manifest

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,7 @@ function install() {
 
 	cat >"${install_path}/plugin.yaml" <<END
 name: "diff"
-version: "asdf"
+version: "$version"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Tools like [helmfile](https://github.com/helmfile/helmfile) will check the version of the plugin for specific functionality. It needs to be semver compliant.

After the change,

```
asdf plugin add helm-diff
asdf install helm-diff 3.9.12
asdf local helm-diff 3.9.12
cat ~/.asdf/installs/helm-diff/3.9.12/plugin.yaml
```

will produce
```
name: "diff"
version: "3.9.12"
usage: "Preview helm upgrade changes as a diff"
description: "Preview helm upgrade changes as a diff"
useTunnel: true
command: "helm-diff"
```